### PR TITLE
Created skeleton for Solver_Py, updated CMakeLists with source

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ build*
 *.out
 *.app
 include_gardener
+
+# VSCode
+.vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,8 @@ set (SOURCE_FILES
   ${CMAKE_SOURCE_DIR}/src/input_files.cpp
   ${CMAKE_SOURCE_DIR}/src/vertex.cpp
   ${CMAKE_SOURCE_DIR}/src/solver.cpp
-  ${CMAKE_SOURCE_DIR}/src/solver_c.cpp )
+  ${CMAKE_SOURCE_DIR}/src/solver_c.cpp
+  ${CMAKE_SOURCE_DIR}/src/solver_py.cpp )
 
 set (EXEC_SOURCE_FILES
   ${SOURCE_FILES}

--- a/inc/solver_py.h
+++ b/inc/solver_py.h
@@ -1,0 +1,100 @@
+// Include-Gardener
+//
+// Copyright (C) 2019  Christian Haettich [feddischson]
+//
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation;
+// either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General
+// Public License along with this program; if not, see
+// <http://www.gnu.org/licenses/>.
+//
+#ifndef SOLVER_PY_H
+#define SOLVER_PY_H
+
+#include "solver.h"
+
+#include <memory>
+
+namespace INCLUDE_GARDENER {
+
+/// @brief Solver class for Python language.
+/// @details
+///   To be implemented.
+
+class Solver_Py : public Solver {
+
+ public:
+  /// @brief Smart pointer for Solver_Py
+  using Ptr = std::shared_ptr<Solver_Py>;
+
+  /// @brief Default ctor.
+  Solver_Py() = default;
+
+  /// @brief Copy ctor: not implemented!
+  Solver_Py(const Solver_Py &other) = delete;
+
+  /// @brief Assignment operator: not implemented!
+  Solver_Py &operator=(const Solver_Py &rhs) = delete;
+
+  /// @brief Move constructor: not implemented!
+  Solver_Py(Solver_Py &&rhs) = delete;
+
+  /// @brief Move assignment operator: not implemented!
+  Solver_Py &operator=(Solver_Py &&rhs) = delete;
+
+  /// @brief Default dtor
+  ~Solver_Py() override = default;
+
+  /// @brief Adds an edge to the graph.
+  /// @param src_path Path the the source path (where the statement is detected).
+  /// @param statement The detected statement
+  /// @param idx The index of the regular expression, which matched.
+  /// @param line_no The line number where the statement is detected.
+  void add_edge(const std::string &src_path, const std::string &statement,
+                unsigned int idx, unsigned int line_no) override;
+
+  /// @brief Returns the regex which
+  ///        detects the statements.
+  std::vector<std::string> get_statement_regex() const override;
+
+  /// @brief Returns the regex which
+  ///        detects the files.
+  std::string get_file_regex() const override;
+
+  /// @brief Extracts solver-specific options (variables).
+  void extract_options(
+      const boost::program_options::variables_map &vm) override;
+
+  /// @brief Adds solver-specific options.
+  static void add_options(boost::program_options::options_description *options);
+
+ protected:
+  /// @brief Adds an edge
+  /// @param src_path Path the the source path (where the statement is detected).
+  /// @param dst_path Path of the destination file (the file which is included).
+  /// @param name The statement (mostly the name of the file).
+  /// @param line_no The line number where the statement is detected.
+  virtual void insert_edge(const std::string &src_path,
+                           const std::string &dst_path, const std::string &name,
+                           unsigned int line_no);
+
+ private:
+  /// @brief Search path for include statements.
+  std::vector<std::string> include_paths;
+};  // class Solver_Py
+
+}  // namespace INCLUDE_GARDENER
+
+#endif // SOLVER_PY_H
+
+// vim: filetype=cpp et ts=2 sw=2 sts=2

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@
 
 #include "file_detector.h"
 #include "solver_c.h"
+#include "solver_py.h"
 #include "statement_detector.h"
 
 using std::cerr;

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -30,6 +30,7 @@
 #include <boost/property_map/transform_value_property_map.hpp>
 
 #include "solver_c.h"
+#include "solver_py.h"
 
 using std::make_shared;
 using std::string;
@@ -64,9 +65,15 @@ void Solver::add_options(boost::program_options::options_description* options) {
 }
 
 Solver::Ptr Solver::get_solver(const std::string& name) {
+
   if (name == "c") {
     return std::dynamic_pointer_cast<Solver>(std::make_shared<Solver_C>());
   }
+
+  if (name == "py"){
+    return std::dynamic_pointer_cast<Solver>(std::make_shared<Solver_Py>());
+  }
+
   return nullptr;
 }
 

--- a/src/solver_py.cpp
+++ b/src/solver_py.cpp
@@ -1,0 +1,66 @@
+// Include-Gardener
+//
+// Copyright (C) 2019  Christian Haettich [feddischson]
+//
+// This program is free software; you can redistribute it
+// and/or modify it under the terms of the GNU General Public
+// License as published by the Free Software Foundation;
+// either version 3 of the License, or (at your option)
+// any later version.
+//
+// This program is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the
+// implied warranty of MERCHANTABILITY or FITNESS FOR A
+// PARTICULAR PURPOSE. See the GNU General Public License
+// for more details.
+//
+// You should have received a copy of the GNU General
+// Public License along with this program; if not, see
+// <http://www.gnu.org/licenses/>.
+//
+#include "solver_py.h"
+
+#include <string>
+#include <vector>
+
+#include <boost/filesystem.hpp>
+#include <boost/log/trivial.hpp>
+
+namespace INCLUDE_GARDENER {
+
+namespace po = boost::program_options;
+using std::mutex;
+using std::string;
+using std::unique_lock;
+using std::vector;
+
+vector<string> Solver_Py::get_statement_regex() const {
+  vector<string> regex_str = {};
+  return regex_str;
+}
+
+string Solver_Py::get_file_regex() const { return string(""); }
+
+void Solver_Py::add_options(po::options_description *options __attribute__((unused))) {
+
+}
+
+void Solver_Py::extract_options(const po::variables_map &vm __attribute__((unused))) {
+
+}
+
+void Solver_Py::add_edge(const string &src_path __attribute__((unused)),
+                         const string &statement __attribute__((unused)),
+                         unsigned int idx __attribute__((unused)),
+                         unsigned int line_no __attribute__((unused))) {
+}
+
+void Solver_Py::insert_edge(const std::string &src_path __attribute__((unused)),
+                            const std::string &dst_path __attribute__((unused)),
+                            const std::string &name __attribute__((unused)),
+                            unsigned int line_no __attribute__((unused))) {
+}
+
+}  // namespace INCLUDE_GARDENER
+
+// vim: filetype=cpp et ts=2 sw=2 sts=2

--- a/src/solver_py.cpp
+++ b/src/solver_py.cpp
@@ -39,7 +39,7 @@ vector<string> Solver_Py::get_statement_regex() const {
   return regex_str;
 }
 
-string Solver_Py::get_file_regex() const { return string(""); }
+string Solver_Py::get_file_regex() const { return string("^[^\\d\\W]\\w*\\.(?i)py[3w]?$"); }
 
 void Solver_Py::add_options(po::options_description *options __attribute__((unused))) {
 


### PR DESCRIPTION
The Solver_Py.h and Solver_Py.cpp files that were created should be similar to the C-implementation. 
Most functionality has been stripped in Solver_Py.cpp. Because of this some parameters are unused, which resulted in build errors. To silence these errors the variables have been given the attribute unused:

```
__attribute__((unused))
```

These attributes should be removed when an implementation uses the value(s) in the function.