### PR TITLE
Removed from file regex ^ and (?i), files are now detected properly

### DIFF
--- a/src/solver_py.cpp
+++ b/src/solver_py.cpp
@@ -35,11 +35,11 @@ using std::unique_lock;
 using std::vector;
 
 vector<string> Solver_Py::get_statement_regex() const {
-  vector<string> regex_str = {};
+  vector<string> regex_str = {R"([ \t]*import[ \t]+([^\d\W][\w.]*)[ \t]*)"};
   return regex_str;
 }
 
-string Solver_Py::get_file_regex() const { return string("^[^\\d\\W]\\w*\\.(?i)py[3w]?$"); }
+string Solver_Py::get_file_regex() const { return string("[^\\d\\W]\\w*\\.py[3w]?$"); }
 
 void Solver_Py::add_options(po::options_description *options __attribute__((unused))) {
 


### PR DESCRIPTION
It should now be possible to detect files and create a .dot file from Python files. No edges are generated yet, but all nodes should be.

There was a slight problem with the "^" being at the beginning of the file-regex; this made all paths that were tested (ex. /hello/world/file.py) to be ignored since the whole path was evaluated. Now the match is only done with the "$" character meaning that it matches from the end (which is also how the C/C++ version regexes function).

I also removed (?i) from the file regex since the regex is initialized with ```boost::regex::icase```, which is practically the same thing. Please try this out on a Python project if you are interested!

I used these program arguments:
```-P <insert-your-path-to-project> -l py```

You should not get an empty digraph! 👍 

